### PR TITLE
fix: default denominator

### DIFF
--- a/packages/fraction/src/Fraction.ts
+++ b/packages/fraction/src/Fraction.ts
@@ -68,7 +68,7 @@ export class Fraction {
       [numerator, denominator] = numerator;
     }
     this.numerator = BigInt(numerator);
-    this.denominator = BigInt(denominator ?? 1n);
+    this.denominator = BigInt(denominator || 1n);
     if (this.denominator === 0n) throw new Error(FractionError.DivisionByZero);
   }
 


### PR DESCRIPTION
This pull request includes a small change to the `Fraction` class in the `Fraction.ts` file. The change updates the initialization of the `denominator` property to use the logical OR (`||`) operator instead of the nullish coalescing (`??`) operator.